### PR TITLE
Show confirm message when deleting

### DIFF
--- a/screens/delete.go
+++ b/screens/delete.go
@@ -18,13 +18,24 @@ func makeDeleteBtn(window fyne.Window) *widget.Button {
 				return
 			}
 
-			err := ses.DeleteSEStemplate(&currSelectedTemplate.Text)
-			if err != nil {
-				dialog.ShowError(errors.New("Fail to delete"), window)
-				fyne.LogError("fail to delete", err)
-			} else {
-				updateTemplateList()
+			deletionConfirmCallback := func(response bool) {
+				if !response {
+					return
+				}
+
+				err := ses.DeleteSEStemplate(&currSelectedTemplate.Text)
+				if err != nil {
+					dialog.ShowError(errors.New("Fail to delete"), window)
+					fyne.LogError("fail to delete", err)
+				} else {
+					updateTemplateList()
+				}
 			}
+
+			cnf := dialog.NewConfirm("Confirmation", "Are you sure to delete a this template?", deletionConfirmCallback, window)
+			cnf.SetDismissText("No")
+			cnf.SetConfirmText("Yes")
+			cnf.Show()
 		})
 	return delBtn
 }

--- a/screens/delete.go
+++ b/screens/delete.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"errors"
+	"fmt"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/dialog"
@@ -32,7 +33,7 @@ func makeDeleteBtn(window fyne.Window) *widget.Button {
 				}
 			}
 
-			cnf := dialog.NewConfirm("Confirmation", "Are you sure to delete a this template?", deletionConfirmCallback, window)
+			cnf := dialog.NewConfirm("Confirmation", fmt.Sprintf("Are you sure to delete \"%s\"", currSelectedTemplate.Text), deletionConfirmCallback, window)
 			cnf.SetDismissText("No")
 			cnf.SetConfirmText("Yes")
 			cnf.Show()


### PR DESCRIPTION
in the first implementation, there was no confirmation on deletion. it's a horrible UX.
showing confirm message is a better UX to user when deleting. 

![delete](https://user-images.githubusercontent.com/43738420/97130267-470ba700-1784-11eb-8e50-c9cb4fc9673a.png)
